### PR TITLE
PINT-811 - Check user agent before Rest API logging

### DIFF
--- a/Model/Config/FastIntegrationConfig.php
+++ b/Model/Config/FastIntegrationConfig.php
@@ -33,7 +33,7 @@ class FastIntegrationConfig
     const XPATH_FAST_PROD_JS_URL = 'fast_integration/fast/fast_prod_js_url';
     const XPATH_ENABLE_DARK_THEME = 'fast_integration/fast/enable_dark_theme';
     const XPATH_ENABLE_DEBUG_LOGGING = 'fast_integration/fast/enable_debug_logging';
-    const XPATH_ENABLE_REST_API_LOG = 'fast_integration/fast/enable_rest_api_log';
+    const XPATH_ENABLE_REST_API_LOG = 'fast_integration/rest_api_log/enable_rest_api_log';
     const XPATH_RETRY_FAILURES_COUNT = 'fast_integration/fast/retry_failures_count';
     const XPATH_ENABLE_AUTH_CAPTURE = 'fast_integration/fast/enable_auth_capture';
     const XPATH_ORDER_STATUS_PLANNED_TO_SHIP = 'fast_integration/fast/order_status_planned_to_ship';

--- a/Plugin/RestApiLog.php
+++ b/Plugin/RestApiLog.php
@@ -20,6 +20,7 @@ use Fast\Checkout\Api\RestApiLogRepositoryInterface as RestApiLogRepository;
 use Fast\Checkout\Model\Config\FastIntegrationConfig;
 use Fast\Checkout\Model\RestApiLogFactory;
 use Magento\Framework\App\RequestInterface;
+use Magento\Framework\HTTP\Header;
 use Magento\Webapi\Controller\Rest;
 use Psr\Log\LoggerInterface;
 
@@ -45,6 +46,11 @@ class RestApiLog
     protected $fastIntegrationConfig;
 
     /**
+     * @var Magento\Framework\HTTP\Header
+     */
+    protected $httpHeader;
+
+    /**
      * @var LoggerInterface
      */
     protected $logger;
@@ -59,11 +65,13 @@ class RestApiLog
         RestApiLogRepository $restApiLogRepository,
         RestApiLogFactory $restApiLogFactory,
         FastIntegrationConfig $fastIntegrationConfig,
+        Header $httpHeader,
         LoggerInterface $logger
     ) {
         $this->restApiLogRepository = $restApiLogRepository;
         $this->restApiLogFactory = $restApiLogFactory;
         $this->fastIntegrationConfig = $fastIntegrationConfig;
+        $this->httpHeader = $httpHeader;
         $this->logger = $logger;
     }
 
@@ -80,7 +88,10 @@ class RestApiLog
         RequestInterface $request
     ) {
 
-        if ($this->fastIntegrationConfig->isRestApiLogEnabled()) {
+        if (
+            $this->fastIntegrationConfig->isRestApiLogEnabled()
+            && strpos((string) $this->httpHeader->getHttpUserAgent(), 'fastplatform') !== false
+        ) {
             $restApiLog = $this->restApiLogFactory->create();
             $restApiLog->setSource($request->getClientIp());
             $restApiLog->setMethod($request->getMethod());

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -14,8 +14,10 @@
                 <retry_failures_cron>*/5 * * * *</retry_failures_cron>
                 <retry_failures_count>2</retry_failures_count>
                 <enable_auto_invoice>0</enable_auto_invoice>
-                <enable_rest_api_log>0</enable_rest_api_log>
             </fast>
+            <rest_api_log>
+                <enable_rest_api_log>0</enable_rest_api_log>
+            </rest_api_log>
          </fast_integration>
         <payment>
             <fast>


### PR DESCRIPTION
Check the user agent on Rest API requests to ensure that "fastplatform" is in the user agent string before logging the request.