### PR TITLE
PINT-812 - Switch to use `getMethod` for checking payment method

### DIFF
--- a/Observer/CreateInvoiceOnShipment.php
+++ b/Observer/CreateInvoiceOnShipment.php
@@ -100,7 +100,7 @@ class CreateInvoiceOnShipment implements ObserverInterface
         if ($this->fastConfig->isEnabled()
             && $this->fastConfig->isEnabledAutoInvoice()
             && $order->getData('fast_order_id')
-            && $order->getPayment()->getAdditionalInformation("method_title") === 'fast') {
+            && $order->getPayment()->getMethod() === 'fast') {
             try {
                 $this->fastCheckoutHelper->log("generating invoice for order: " . $order->getIncrementId() . " fast order id " . $order->getData('fast_order_id'));
 

--- a/Observer/InvoiceFastOrderWithCapture.php
+++ b/Observer/InvoiceFastOrderWithCapture.php
@@ -103,7 +103,7 @@ class InvoiceFastOrderWithCapture implements ObserverInterface
         if ($fastOrderId
             && $this->fastConfig->isEnabled()
             && !$this->fastConfig->isAuthCapture()
-            && $order->getPayment()->getAdditionalInformation("method_title") === 'fast') {
+            && $order->getPayment()->getMethod() === 'fast') {
             try {
                 $orderComment = sprintf(
                     __("Invoicing Fast order ID: %s"),

--- a/Plugin/Sales/Model/OrderPlugin.php
+++ b/Plugin/Sales/Model/OrderPlugin.php
@@ -90,7 +90,7 @@ class OrderPlugin
     {
         if ($this->fastConfig->isEnabled()
             && $order->getFastOrderId()
-            && $order->getPayment()->getAdditionalInformation("method_title") === 'fast') {
+            && $order->getPayment()->getMethod() === 'fast') {
             $this->logger->debug("in beforeCancel order");
             $callback = $this->fastConfig->getFastApiUri() . static::FAST_ORDER_CANCEL_ENDPOINT;
             $callback = str_replace(':order_id.value', $order->getFastOrderId(), $callback);

--- a/Plugin/Sales/Model/StatusOnCapture.php
+++ b/Plugin/Sales/Model/StatusOnCapture.php
@@ -66,7 +66,7 @@ class StatusOnCapture
         if ($this->fastConfig->isEnabled()
             && $order->getData('fast_order_id')
             && $order->getState() == Order::STATE_PROCESSING
-            && $order->getPayment()->getAdditionalInformation("method_title") === 'fast') {
+            && $order->getPayment()->getMethod() === 'fast') {
             $state = Order::STATE_PROCESSING;
             $status = $this->fastConfig->getInvoicedOrderStatus();
             $order->setState($state);


### PR DESCRIPTION
This pulls in the method code instead of the method title for comparison because the method title can be modified in the Magento admin.