### PR TITLE
Update refund transaction ID

### DIFF
--- a/Model/Payment/FastPayment.php
+++ b/Model/Payment/FastPayment.php
@@ -236,22 +236,23 @@ class FastPayment extends AbstractMethod
      */
     public function refund(InfoInterface $payment, $amount)
     {
-        $transactionId = $payment->getParentTransactionId();
+        $transactionId = $this->fastCheckoutHelper->guid() . '-' . Transaction::TYPE_REFUND;
+        $parentTransactionId = $payment->getParentTransactionId();
         $this->fastCheckoutHelper->log('transaction id in refund: ' . $transactionId, Logger::DEBUG);
         $order = $payment->getOrder();
         if ($order->getFastOrderId()) {
             try {
                 $this->fastCheckoutHelper->log("in before Refund", Logger::DEBUG);
                 // send fast the refund request
-                $this->sendRefund($order, $payment, $amount);
+                $this->sendRefund($order, $payment, $amount, $transactionId);
             } catch (\Exception $e) {
                 $this->fastCheckoutHelper->log($e->getMessage());
                 throw new CouldNotSaveException(__('Payment refunding error.'));
             }
 
             $payment
-                ->setTransactionId($transactionId . '-' . Transaction::TYPE_REFUND)
-                ->setParentTransactionId($transactionId)
+                ->setTransactionId($transactionId)
+                ->setParentTransactionId($parentTransactionId)
                 ->setIsTransactionClosed(1)
                 ->setShouldCloseParentTransaction(1);
         } else {
@@ -311,10 +312,11 @@ class FastPayment extends AbstractMethod
      * @param $order
      * @param $payment
      * @param $amount
+     * @param $transactionId
      * @return bool
      * @throws LocalizedException
      */
-    protected function sendRefund($order, $payment, $amount)
+    protected function sendRefund($order, $payment, $amount, $transactionId)
     {
         if ($amount <= 0) {
             throw new LocalizedException(__('Invalid amount for refund.'));
@@ -323,8 +325,8 @@ class FastPayment extends AbstractMethod
         if ($amount > $order->getBaseGrandTotal()) {
             throw new LocalizedException(__('Invalid amount for refund.'));
         }
-        $transactionId = $payment->getParentTransactionId();
-        if ($transactionId) {
+        $parentTransactionId = $payment->getParentTransactionId();
+        if ($parentTransactionId) {
             $callback = $this->fastConfig->getFastApiUri() . static::FAST_REFUND_ENDPOINT;
             $callback = str_replace(':order_id.value', $order->getFastOrderId(), $callback);
             $payload = [


### PR DESCRIPTION
See PINT-930.

Set a unique transaction ID for each refund to ensure that partial refunds do not have the same ID.