### PR TITLE
Update vendor name for avoiding collision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "fast/module-checkout",
+  "name": "fastaf/module-checkout",
   "description": "Magento Fast Checkout Extension - A Checkout and Payment solution for Magento using the Fast checkout interface",
   "version": "1.1.0.7",
   "minimum-stability": "stable",


### PR DESCRIPTION
Currently Fast vendor name collides with someother vendor, and we are not able to submit package.
This will make it consistent with the authors name