### PR TITLE
[PINT-1145] Update default attribute options

### DIFF
--- a/Setup/Patch/Data/AddShowFastAttributePatch.php
+++ b/Setup/Patch/Data/AddShowFastAttributePatch.php
@@ -95,8 +95,8 @@ class AddShowFastAttributePatch implements DataPatchInterface
             'used_in_product_listing' => true,
             'visible_on_front' => true,
             'user_defined' => false,
-            'filterable' => true,
-            'filterable_in_search' => true,
+            'filterable' => false,
+            'filterable_in_search' => false,
             'used_for_promo_rules' => true,
             'is_html_allowed_on_front' => true,
             'used_for_sort_by' => false


### PR DESCRIPTION
The product attribute used to determine if products should be eligible for Fast checkout appears on the front-end if not manually removed from listing in the Magento admin panel. We should make it not be listed in Layered Navigation by default so Sellers don’t have to change this setting to avoid Fast being listed.