### PR TITLE
Expose Fast_Order_Id/Fast_Order_Item_Uuid to Cart/CartItem GraphQl

### DIFF
--- a/Model/Resolver/Cart/FastOrderId.php
+++ b/Model/Resolver/Cart/FastOrderId.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Fast_Checkout
+ *
+ * PHP version 7.3
+ *
+ * @package   Fast_Checkout
+ * @author    Fast <hi@fast.co>
+ * @copyright 2021 Copyright Fast AF, Inc., https://www.fast.co/
+ * @license   https://opensource.org/licenses/OSL-3.0 OSL-3.0
+ * @link      https://www.fast.co/
+ */
+
+declare(strict_types=1);
+
+namespace Fast\Checkout\Model\Resolver\Cart;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
+
+class FastOrderId implements ResolverInterface
+{
+    const FAST_ORDER_ID= 'fast_order_id';
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+        /** @var Quote $cart */
+        $cart = $value['model'];
+        return $cart->getData(static::FAST_ORDER_ID);
+    }
+}

--- a/Model/Resolver/CartItem/FastOrderItemUuid.php
+++ b/Model/Resolver/CartItem/FastOrderItemUuid.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Fast_Checkout
+ *
+ * PHP version 7.3
+ *
+ * @package   Fast_Checkout
+ * @author    Fast <hi@fast.co>
+ * @copyright 2021 Copyright Fast AF, Inc., https://www.fast.co/
+ * @license   https://opensource.org/licenses/OSL-3.0 OSL-3.0
+ * @link      https://www.fast.co/
+ */
+
+declare(strict_types=1);
+
+namespace Fast\Checkout\Model\Resolver\CartItem;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
+
+class FastOrderItemUuid implements ResolverInterface
+{
+    const FAST_ORDER_ITEM_UUID_NAME = 'fast_order_item_uuid';
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+        /** @var Item $cartItem */
+        $cartItem = $value['model'];
+        return $cartItem->getData(static::FAST_ORDER_ITEM_UUID_NAME);
+    }
+}

--- a/Plugin/Resolver/AddProductsToCartWithFastItemUuid.php
+++ b/Plugin/Resolver/AddProductsToCartWithFastItemUuid.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Fast\Checkout\Plugin\Resolver;
+
+use Closure;
+use Magento\QuoteGraphQl\Model\Resolver\AddProductsToCart\Interceptor;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\App\ResourceConnection;
+
+/**
+ * Class AddProductsToCartWithFastItemUuid
+ */
+class AddProductsToCartWithFastItemUuid
+{
+    protected $resourceConnection;
+    private $logger;
+
+    public function __construct(
+        \Psr\Log\LoggerInterface $logger,
+        ResourceConnection $resourceConnection
+    ) {
+        $this->logger = $logger;
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    public function aroundResolve(
+        Interceptor $subject,
+        Closure $proceed,
+        Field $field, 
+        $context, 
+        ResolveInfo $info, 
+        array $value = null,
+        array $args = null
+    ) {
+        $result = $proceed($field, $context, $info, $value, $args);
+
+        $cart = $result['cart']['model'];
+        $cartItems = $args['cartItems'];
+        $connection = $this->resourceConnection->getConnection();
+        $skuToFastId = [];
+        foreach ($cartItems as $cartItem) {
+            if (isset($cartItem['fast_order_item_uuid'])) {
+                $skuToFastId[$cartItem['sku']] = $cartItem['fast_order_item_uuid'];
+            }
+        }
+
+        $this->logger->info('add product run');
+
+        foreach ($cart->getItems() as $cItem) {
+            $fastOrderItemUuid = $skuToFastId[$cItem->getSku()];
+
+            // update DB directly to save fast_order_item_uuid, similar to /Plugin/Uuid/AddFastOrderItemUuid
+            $query = "UPDATE `quote_item` SET `fast_order_item_uuid`= '" . $fastOrderItemUuid . "' WHERE item_id = " . $cItem->getItemId();
+            $connection->query($query);
+
+            $extensionAttributes = $cItem->getExtensionAttributes();
+            $cItem->setData('fast_order_item_uuid', $fastOrderItemUuid);
+            $extensionAttributes->setFastOrderItemUuid($fastOrderItemUuid);
+            $cItem->setExtensionAttributes($extensionAttributes);
+        }
+
+        return $result;
+    }
+}

--- a/Plugin/Resolver/CreateEmptyCartWithFastOrderId.php
+++ b/Plugin/Resolver/CreateEmptyCartWithFastOrderId.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Fast\Checkout\Plugin\Resolver;
+
+use Closure;
+use \Magento\Framework\App\Http\Context;
+use Magento\QuoteGraphQl\Model\Resolver\CreateEmptyCart\Interceptor;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+/**
+ * Class CreateEmptyCartWithFastOrderId
+ */
+class CreateEmptyCartWithFastOrderId
+{
+    const CONTEXT_FAST_ORDER_ID_KEY = 'fast_order_id';
+
+    protected $httpContext;
+
+    public function __construct(
+        Context $httpContext
+    ) {
+        $this->httpContext = $httpContext;
+    }
+
+    public function aroundResolve(
+        Interceptor $subject,
+        Closure $proceed,
+        Field $field, 
+        $context, 
+        ResolveInfo $info, 
+        array $value = null,
+        array $args = null
+    ) {
+        if (isset($args['input']['fast_order_id'])) {
+            // pass along the fast_order_id, so Plugin/Api/CartManagement can pick it up
+            $this->httpContext->setValue(self::CONTEXT_FAST_ORDER_ID_KEY, $args['input']['fast_order_id'], null);
+        }
+
+        return $proceed($field, $context, $info, $value, $args);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -80,4 +80,11 @@
             </argument>
         </arguments>
     </virtualType>
+
+    <type name="Magento\QuoteGraphQl\Model\Resolver\CreateEmptyCart">
+        <plugin name="save_fast_order_id_to_cart_gql" type="Fast\Checkout\Plugin\Resolver\CreateEmptyCartWithFastOrderId"/>
+    </type>
+    <type name="Magento\QuoteGraphQl\Model\Resolver\AddProductsToCart">
+        <plugin name="save_fast_item_uuid_cart_item_gql" type="Fast\Checkout\Plugin\Resolver\AddProductsToCartWithFastItemUuid"/>
+    </type>
 </config>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,16 @@
+
+type Cart {
+    fast_order_id: String @resolver(class: "\\Fast\\Checkout\\Model\\Resolver\\Cart\\FastOrderId")
+}
+
+interface CartItemInterface {
+    fast_order_item_uuid: String @resolver(class: "\\Fast\\Checkout\\Model\\Resolver\\CartItem\\FastOrderItemUuid")
+}
+
+input createEmptyCartInput {
+    fast_order_id: String
+}
+
+input CartItemInput {
+    fast_order_item_uuid: String
+}


### PR DESCRIPTION
1. Expose fast_order_id to cart query
2. Expose fast_order_item_uuid to cart item query
3. Support setting fast_order_id in cart mutation
4. Support setting fast_order_item_uuid in cart item mutation

The following are not done yet:
1. Expose fast_order_id to order query
2. Expose fast_order_item_uuid to order item query